### PR TITLE
Added tile cache time limit for tiles.

### DIFF
--- a/WMSOnMapKit/MapViewUtils.h
+++ b/WMSOnMapKit/MapViewUtils.h
@@ -14,6 +14,7 @@
 #define MAXIMUM_ZOOM 25
 
 #define TILE_CACHE   @"TILE_CACHE"
+#define TILE_CACHE_TIME_LIMIT 7200 // 2 hours
 
 
 //------------------------------------------------------------


### PR DESCRIPTION
The tile's `fileCreationDate` is compared to the tile cache time limit to to determine if the age is less than the limit.